### PR TITLE
neo-ai-tvm: fix TVM runtime problem

### DIFF
--- a/recipes-neo-ai/neo-ai-tvm/neo-ai-tvm.bb
+++ b/recipes-neo-ai/neo-ai-tvm/neo-ai-tvm.bb
@@ -8,9 +8,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e \
                     file://3rdparty/HalideIR/LICENSE;md5=9910386e68f0616e1ecf1037479fa97e \
 "
 
+RDEPENDS_${PN} = " python3-decorator \
+"
+
 PV = "0.5"
 
-BRANCH ?= "v${PV}"
+BRANCH = "master"
 
 # Main TVM sources plus submodules.
 SRC_URI = "git://github.com/dmlc/tvm;protocol=https;branch=${BRANCH};name=tvm \
@@ -21,7 +24,7 @@ SRC_URI = "git://github.com/dmlc/tvm;protocol=https;branch=${BRANCH};name=tvm \
            file://0001-CMakeLists-install-unit-tests.patch \
 "
 
-SRCREV_tvm = "f08015e7fde92c835907d4c9b7ad6d3f634e94a5"
+SRCREV_tvm = "76c239269935288e51fbce14f135d75ad9742b2a"
 SRCREV_dmlc-core = "d07fb7a443b5db8a89d65a15a024af6a425615a5"
 SRCREV_halideir = "b257a9221ee1e5180d994b3488ddcc259b0ac157"
 SRCREV_dlpack = "5c792cef3aee54ad8b7000111c9dc1797f327b59"

--- a/recipes-neo-ai/neo-ai-tvm/neo-ai-tvm/0001-CMakeLists-install-unit-tests.patch
+++ b/recipes-neo-ai/neo-ai-tvm/neo-ai-tvm/0001-CMakeLists-install-unit-tests.patch
@@ -1,26 +1,29 @@
-From 2663c9682e427ce64f5bfa53e1ee389f80133cac Mon Sep 17 00:00:00 2001
-From: Jacob Stiffler <j-stiffler@ti.com>
-Date: Wed, 14 Aug 2019 16:27:51 -0400
-Subject: [PATCH] CMakeLists: install unit tests
+From 5904aa69d8f022678aa19dd4c1b5569d5fc243ee Mon Sep 17 00:00:00 2001
+From: Jianzhong Xu <xuj@ti.com>
+Date: Tue, 8 Oct 2019 16:56:30 -0400
+Subject: [PATCH] [PATCH] CMakeLists: install unit tests
 
 * Install the unittests (cpptest) to /usr/share/tvm/cpptest
 * For simplicity, do not exclude cpptest from the default build.
 
 Upstream-Status: Innappropriate [Configuration]
 
-Signed-off-by: Jacob Stiffler <j-stiffler@ti.com>
+Signed-off-by: Jianzhong Xu <xuj@ti.com>
 ---
  CMakeLists.txt | 5 +++--
  1 file changed, 3 insertions(+), 2 deletions(-)
+ mode change 100644 => 100755 CMakeLists.txt
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 494afbd..7e887f6 100644
+old mode 100644
+new mode 100755
+index 10730ac7..ea369a6e
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -233,10 +233,11 @@ if(GTEST_LIB)
+@@ -333,10 +333,11 @@ if(GTEST_INCLUDE_DIR AND GTEST_LIB)
      list(APPEND TEST_EXECS ${__execname})
-     target_link_libraries(${__execname}
-       tvm ${GTEST_LIB} pthread)
+     target_include_directories(${__execname} PUBLIC ${GTEST_INCLUDE_DIR})
+     target_link_libraries(${__execname} tvm ${GTEST_LIB} pthread dl)
 -    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
 -    set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
 +    #set_target_properties(${__execname} PROPERTIES EXCLUDE_FROM_ALL 1)
@@ -28,9 +31,9 @@ index 494afbd..7e887f6 100644
    endforeach()
    add_custom_target(cpptest DEPENDS ${TEST_EXECS})
 +  install(TARGETS ${TEST_EXECS} DESTINATION share/tvm/cpptest)
- endif()
- 
- # Custom targets
+ elseif(NOT GTEST_INCLUDE_DIR)
+   add_custom_target(cpptest
+       COMMAND echo "Missing Google Test headers in include path"
 -- 
-2.7.4
+2.17.1
 


### PR DESCRIPTION
* add run-time depends of Python3 decorator
* use newer code (Mon Oct 7) from TVM master branch
* update patch file accordingly

Signed-off-by: Jianzhong Xu <xuj@ti.com>

*Issue #, if available:*
N/A

*Description of changes:*
Fix TVM runtime problem:
* add run-time depends of Python3 decorator
* use newer code (Mon Oct 7) from TVM master branch
* update patch file accordingly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
