### PR TITLE
greengrass-core: Ignore commented sysctl variables

### DIFF
--- a/recipes-greengrass/greengrass-core/greengrass.inc
+++ b/recipes-greengrass/greengrass-core/greengrass.inc
@@ -59,7 +59,7 @@ do_install() {
 
 pkg_postinst_ontarget_${PN}() {
     # Enable protection for hardlinks and symlinks
-    if ! grep -qs 'protected_.*links' $D${sysconfdir}/sysctl.conf; then
+    if ! grep -qs 'protected_.*links' $D${sysconfdir}/sysctl.conf | grep -v '^#'; then
     cat >> $D${sysconfdir}/sysctl.conf <<-_EOF_
 # Greengrass: protect hardlinks/symlinks
 fs.protected_hardlinks = 1


### PR DESCRIPTION
The /etc/sysctl.conf file may contain commented 'protected_.*links' lines.
If these lines exist, postinst() will no longer enable protection for
hardlinks and softlinks. This patch fixes this by ignoring these
commented lines.

Signed-off-by: Codrin Ciubotariu <codrin.ciubotariu@microchip.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
