### PR TITLE
greengrass-core: Adds bbappend to patchelf the GG daemon for dyn link…

### DIFF
--- a/recipes-greengrass/greengrass-core/greengrass_1.10.0.bbappend
+++ b/recipes-greengrass/greengrass-core/greengrass_1.10.0.bbappend
@@ -1,0 +1,6 @@
+DEPENDS += "patchelf-native"
+
+do_install_append_qemux86-64() {
+    patchelf --set-interpreter /lib/ld-linux-x86-64.so.2 ${D}/greengrass/ggc/core/bin/daemon
+}
+


### PR DESCRIPTION
… path

GG daemon binary is dynamically linked to /lib64/... (an ubuntu-ism)
This commit uses patchelf to --set-interpreter to replace /lib64 with /lib
for embedded linux. Reference issue #44

Signed-off-by: Paul Butler <butler.paul@gmail.com>

*Issue #, if available:* 44

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
