### PR TITLE
Add aws-iot-securetunneling-localproxy recipe

### DIFF
--- a/recipes-greengrass/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-greengrass/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -1,0 +1,33 @@
+SUMMARY = "AWS Iot Secure Tunneling local proxy reference C++ implementation"
+DESCRIPTION = "When devices are deployed behind restricted firewalls at remote sites, you need a way to gain access to those device for troubleshooting, configuration updates, and other operational tasks. Secure tunneling helps customers establish bidirectional communication to remote devices over a secure connection that is managed by AWS IoT. Secure tunneling does not require updates to your existing inbound firewall rule, so you can keep the same security level provided by firewall rules at a remote site. "
+HOMEPAGE = "https://docs.aws.amazon.com/iot/latest/developerguide/secure-tunneling.html"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+DEPENDS += "boost catch2 openssl protobuf protobuf-native zlib"
+
+PV = "1.0+git${SRCPV}"
+SRC_URI = "git://git@github.com/aws-samples/aws-iot-securetunneling-localproxy.git;protocol=ssh"
+SRCREV = "880b7dad54ea53867ed61ced0ba9fe897a1cfe72"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+do_configure_prepend() {
+    sed -i "s/Protobuf_LITE_STATIC_LIBRARY/Protobuf_LITE_LIBRARY/g" ${S}/CMakeLists.txt
+    sed -i "s/string.*Protobuf_LITE_LIBRARY.*/#&/g" ${S}/CMakeLists.txt
+    sed -i "s/set_property.*PROTOBUF_USE_STATIC_LIBS.*/#&/g" ${S}/CMakeLists.txt
+}
+
+do_install () {
+  install -d ${D}${bindir}
+  install -m 0755 ${B}/bin/localproxy ${D}${bindir}/localproxy
+  install -m 0755 ${B}/bin/localproxytest ${D}${bindir}/localproxytest
+}
+
+PACKAGES =+ "${PN}-tests"
+FILES_${PN} = "${bindir}/localproxy"
+FILES_${PN}-tests = "${bindir}/localproxytest"
+RDEPENDS_${PN}-tests += "${PN}"


### PR DESCRIPTION
*Description of changes:*
Add the aws-iot-securetunneling-localproxy recipe.

Here is the documentation from AWS [https://docs.aws.amazon.com/iot/latest/developerguide/secure-tunneling.html](https://docs.aws.amazon.com/iot/latest/developerguide/secure-tunneling.html) about it.

Notes. I disabled the statically linkage of Protobuf lite because by default Protobuf produces shared library. In its CMakefiles, protobuf can either generate shared or static. To use the default static libraries required by localproxy, the user would have to give up the shared library, which could fail many other recipes. I don't think it's good to force a change of a build just for this recipe is good, hence the sed commands.

I tested it, works well on qemu since the tunnel works from my laptop to the VM.

Any chance this can also be pushed to earlier versions, especially Warrior?

Thanks!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
