### PR TITLE
greengrass: Fix cgroup mount at first boot

### DIFF
--- a/recipes-greengrass/greengrass-core/greengrass.inc
+++ b/recipes-greengrass/greengrass-core/greengrass.inc
@@ -78,6 +78,7 @@ _EOF_
 				# Greengrass: mount cgroups
 				cgroup    /sys/fs/cgroup    cgroup    defaults    0  0
 			_EOF_
+			mount -at cgroup 2>/dev/null
 		fi
 	fi
 


### PR DESCRIPTION
The post install script updates the fstab with an entry to mount cgroup
at boot time. However, since the mount service has a lower runlevel than
greengrass (3 vs 80), the cgroup fs is not mounted at first boot. Fix
this by manually running 'mount -a' in the post install script.

Signed-off-by: Codrin Ciubotariu <codrin.ciubotariu@microchip.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
