### PR TITLE
Move distro dependent kernel config to layer config

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,6 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # We have recipes-* directories, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
+BBFILES += "${@bb.utils.contains("DISTRO", "arago", "${LAYERDIR}/recipes-*/*/arago/*.bbappend", "${LAYERDIR}/recipes-*/*/base/*.bbappend", d)}" 
 
 BBFILE_COLLECTIONS += "meta-aws"
 BBFILE_PATTERN_meta-aws = "^${LAYERDIR}/"

--- a/recipes-greengrass/greengrass-core/greengrass.inc
+++ b/recipes-greengrass/greengrass-core/greengrass.inc
@@ -17,17 +17,6 @@ S = "${WORKDIR}/${BPN}"
 
 inherit update-rc.d useradd systemd
 
-# Kernel module override per distribution
-# This is required if the BSP drives the need for differentiation
-python __anonymous () {
-    if d.getVar('DISTRO') == 'arago':
-        d.setVar('GG_KERNEL_MOD', '${THISDIR}/arago')
-    else:
-        d.setVar('GG_KERNEL_MOD', '${THISDIR}/base')
-}
-
-FILESEXTRAPATHS_prepend := "${GG_KERNEL_MOD}:"
-
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 
 # Disable tasks not needed for the binary package

--- a/recipes-greengrass/greengrass-core/greengrass_1.10.1.bb
+++ b/recipes-greengrass/greengrass-core/greengrass_1.10.1.bb
@@ -29,10 +29,15 @@ SRC_URI[x86-64.sha256sum]  = "8fded584f9291510ee91fe98cfd8bc69e01d1b8e4147f24fa1
 
 # Release specific configuration
 
-DEPENDS += "patchelf-native"
 RDEPENDS_${PN} += "ca-certificates python3-json python3-numbers sqlite3 docker python3-docker-compose openjdk-8"
 
 do_install_append_x86-64() {
-    patchelf --set-interpreter /lib/ld-linux-x86-64.so.2 ${D}/greengrass/ggc/core/bin/daemon
-    patchelf --set-interpreter /lib/ld-linux-x86-64.so.2 ${D}/greengrass/ggc/core/lambda/GreengrassSystemComponents/greengrassSystemComponents
+    # create symbolic link /lib64/ld-linux-x86-64.so.2 to enable loading the binary
+    install -d ${D}/lib64
+    cd ${D}/lib64
+    ln -s ../lib/ld-linux-x86-64.so.2 ld-linux-x86-64.so.2
 }
+
+FILES_${PN} += " /lib64"
+INSANE_SKIP_${PN} += " libdir"
+


### PR DESCRIPTION
*Issue #61 *

*Description of changes:*

The location for the bbappend files needs to be configured in the layer config, otherwise it is not picked up by bitbake. Depending on the DISTRO variable, it will use either the arago directory or the base directory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
