### PR TITLE
missing licence file path and checksum were added

### DIFF
--- a/recipes-greengrass/greengrass-core-sdk/aws-greengrass-core-sdk-c_git.bb
+++ b/recipes-greengrass/greengrass-core-sdk/aws-greengrass-core-sdk-c_git.bb
@@ -1,6 +1,8 @@
 SUMMARY = "AWS Greengrass Core SDK C with Example"
 DESCRIPTION = "A simple hello world application"
 LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/\
+${LICENSE};md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 BRANCH = "master"
 SRCREV = "f269fc8d07f2922f49429e1d8bc097d65bb67188"


### PR DESCRIPTION
To resolve following error,

ERROR: aws-greengrass-core-sdk-c-git-r0 do_populate_lic: QA Issue: aws-greengrass-core-sdk-c: Recipe file fetches files and does not have license file information (LIC_FILES_CHKSUM) [license-checksum]
ERROR: aws-greengrass-core-sdk-c-git-r0 do_populate_lic: Fatal QA errors found, failing task.
ERROR: aws-greengrass-core-sdk-c-git-r0 do_populate_lic: Function failed: populate_lic_qa_checksum
ERROR: Logfile of failure stored in: /home/sysadmin/git/QDN/workSpace/apq8009/apps_proc/build-qti-distro-fullstack-debug/tmp-glibc/work/armv7ahf-neon-oe-linux-gnueabi/aws-greengrass-core-sdk-c/git-r0/temp/log.do_populate_lic.19416
ERROR: Task (/home/sysadmin/git/QDN/workSpace/apq8009/apps_proc/poky/meta-aws/recipes-greengrass/greengrass-core-sdk/aws-greengrass-core-sdk-c_git.bb:do_populate_lic) failed with exit code '1'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
