### PR TITLE
aws-iot-device-sdk-python-v2: fix LIC_FILES_CHKSUM

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -2,7 +2,7 @@ SUMMARY = "AWS IoT Device SDK Python v2"
 DESCRIPTION = "AWS IoT SDK based on the AWS Common Runtime"
 HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python-v2.git"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "master"
 


### PR DESCRIPTION
Description of changes:
Since the aws-iot-device-sdk-python-v2 recipe uses AUTOREV, the changes to LICENSE in https://github.com/aws/aws-iot-device-sdk-python-v2 result in a new md5sum breaking the verification. This PR updates the checksum in the recipe to match the new version of LICENSE.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
