### PR TITLE
aws-greengrass-core-sdk-c: don't use trailing slash in S

### DIFF
--- a/recipes-greengrass/greengrass-core-sdk/aws-greengrass-core-sdk-c_git.bb
+++ b/recipes-greengrass/greengrass-core-sdk/aws-greengrass-core-sdk-c_git.bb
@@ -6,7 +6,7 @@ BRANCH = "master"
 SRCREV = "f269fc8d07f2922f49429e1d8bc097d65bb67188"
 SRC_URI = "git://github.com/aws/aws-greengrass-core-sdk-c.git;protocol=https;branch=${BRANCH}"
 
-S = "${WORKDIR}/git/"
+S = "${WORKDIR}/git"
 
 inherit cmake
 


### PR DESCRIPTION
* see oe-core base.bbclass changes from:
  https://lists.openembedded.org/g/openembedded-core/message/143159
  https://lists.openembedded.org/g/openembedded-core/message/143161

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>