### PR TITLE
aws-iot-device-sdk-python-v2: master branch is renamed to main

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python-v2.git"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
-BRANCH ?= "master"
+BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
*Description of changes:*

aws-iot-device-sdk-python-v2 has renamed the master branch to main

It would also be good if this could be backported into relevant release branches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
