### PR TITLE
Change to new master branch name

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
-SRCREV = "${AUTOREV}"
+SRCREV = "844bf38ebb13e316ea8100e364121e616c9e71df"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python-v2.git"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
-BRANCH ?= "master"
+BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
Signed-off-by: Arnstein Kleven <arnsteinkleven@gmail.com>

*Issue #, if available:*
Seems like the aws-iot-device-sdk-python-v2 repo changed the name of their master branch to main, breaking the build.

*Description of changes:*
Changing BRANCH from master to main. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
