### PR TITLE
meta-aws: aws-iot-device-sdk-python-v2: branch transition master to main

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -4,10 +4,10 @@ HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python-v2.git"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
-BRANCH ?= "master"
+BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
-SRCREV = "${AUTOREV}"
+SRCREV = "844bf38ebb13e316ea8100e364121e616c9e71df"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The branch of aws-iot-device-sdk-python-v2 has been changed master to main

Issue #, if available:
I got errors as below.
File "bitbake/lib/bb/fetch2/git.py", line 230, in Git.urldata_init(ud=<bb.fetch2.FetchData object at 0x7fee5bf77160>, d=<bb.data_smart.DataSmart object at 0x7fee5c8a4a58>):

>        ud.setup_revisions(d)
File "bitbake/lib/bb/fetch2/init.py", line 1314, in FetchData.setup_revisions(d=<bb.data_smart.DataSmart object at 0x7fee5c8a4a58>):
for name in self.names:
> self.revisions[name] = srcrev_internal_helper(self, d, name)

File "bitbake/lib/bb/fetch2/init.py", line 1177, in srcrev_internal_helper(ud=<bb.fetch2.FetchData object at 0x7fee5bf77160>, d=<bb.data_smart.DataSmart object at 0x7fee5c8a4a58>, name='aws-iot-device-sdk-python-v2'):
if srcrev == "AUTOINC":
> srcrev = ud.method.latest_revision(ud, d, name)

File "bitbake/lib/bb/fetch2/init.py", line 1592, in Git.latest_revision(ud=<bb.fetch2.FetchData object at 0x7fee5bf77160>, d=<bb.data_smart.DataSmart object at 0x7fee5c8a4a58>, name='aws-iot-device-sdk-python-v2'):
except KeyError:
> revs[key] = rev = self._latest_revision(ud, d, name)
return rev
File "bitbake/lib/bb/fetch2/git.py", line 645, in Git._latest_revision(ud=<bb.fetch2.FetchData object at 0x7fee5bf77160>, d=<bb.data_smart.DataSmart object at 0x7fee5c8a4a58>, name='aws-iot-device-sdk-python-v2'):
raise bb.fetch2.FetchError("Unable to resolve '%s' in upstream git repository in git ls-remote output for %s" %
> (ud.unresolvedrev[name], ud.host+ud.path))

bb.data_smart.ExpansionError: Failure expanding variable SRCPV, expression was ${@bb.fetch2.get_srcrev(d)} which triggered exception FetchError: Fetcher failure: Unable to resolve 'master' in upstream git repository in git ls-remote output for github.com/aws/aws-iot-device-sdk-python-v2.git

Description of changes:
The branch of aws-iot-device-sdk-python-v2 has been changed master to main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.