### PR TITLE
aws-iot-device-sdk-python-v2.inc: fix BRANCH name and use fixed SRCREV

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -4,10 +4,10 @@ HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python-v2.git"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
-BRANCH ?= "master"
+BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
-SRCREV = "${AUTOREV}"
+SRCREV = "844bf38ebb13e316ea8100e364121e616c9e71df"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
* master branch was renamed to main and even just parsing
  this recipe fails with:
    bb.data_smart.ExpansionError: Failure expanding variable SRCPV,
    expression was ${@bb.fetch2.get_srcrev(d)} which triggered
    exception FetchError: Fetcher failure: Unable to resolve
    'master' in upstream git repository in git ls-remote output
    for github.com/aws/aws-iot-device-sdk-python-v2.git
  because of AUTOREV use instead of fixed SRCREV

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>