### PR TITLE
meta-aws: aws-iot-device-sdk-cpp-v2: fix BRANCH name

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.0.bb
@@ -3,7 +3,7 @@ require aws-iot-device-sdk-cpp-v2.inc
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-BRANCH ?= "master"
+BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "65b8344ddb6173d312dff4e759a0dfbc05a97e4c"


### PR DESCRIPTION
The master branch was renamed to main for aws-iot-device-sdk-cpp-v2

*Issue #, if available:*
ERROR: aws-iot-device-sdk-cpp-v2-1.6.0-r0 do_fetch: Fetcher failure: Unable to find revision 65b8344ddb6173d312dff4e759a0dfbc05a97e4c in branch master even from upstream
ERROR: aws-iot-device-sdk-cpp-v2-1.6.0-r0 do_fetch: Fetcher failure for URL: 'git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=master;name=aws-iot-device-sdk-cpp-v2
