### PR TITLE
meta-aws: aws-iot-device-sdk-python-v2: fix BRANCH name

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2.inc
@@ -4,10 +4,10 @@ HOMEPAGE = "https://github.com/aws/aws-iot-device-sdk-python-v2.git"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
-BRANCH ?= "master"
+BRANCH ?= "main"
 
 SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
-SRCREV = "${AUTOREV}"
+SRCREV = "844bf38ebb13e316ea8100e364121e616c9e71df"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The master branch was renamed to main for aws-iot-device-sdk-python-v2.