### PR TITLE
Fix Amazon Corretto 11 SRC_URI for armv7

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.9.12.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.9.12.1.bb
@@ -8,7 +8,7 @@ BASE_aarch64    = "amazon-corretto-${PV}-linux-aarch64"
 SRC_URI_aarch64 = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-aarch64.tar.gz;name=aarch64"
 
 BASE_arm        = "amazon-corretto-${PV}-linux-armv7"
-SRC_URI_arm     = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-.tar.gz;name=arm"
+SRC_URI_arm     = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-armv7.tar.gz;name=arm"
 
 BASE_x86-64     = "amazon-corretto-${PV}-linux-x64"
 SRC_URI_x86-64  = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"


### PR DESCRIPTION
*Issue # N/A:*

Hey guys,

Found a small typo when trying to build `greengrass-bin` for rpi4!

*Description of changes:*

The SRC_URI for this arch was wrong.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
