### PR TITLE
Add a recipe for awscli

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,5 +10,5 @@ BBFILE_COLLECTIONS += "meta-aws"
 BBFILE_PATTERN_meta-aws = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-aws = "6"
 
-LAYERDEPENDS_meta-aws = "core"
+LAYERDEPENDS_meta-aws = "core meta-python"
 LAYERSERIES_COMPAT_meta-aws = "zeus dunfell gatesgarth hardknott"

--- a/recipes-devtools/python/python3-botocore_1.20.36.bb
+++ b/recipes-devtools/python/python3-botocore_1.20.36.bb
@@ -1,0 +1,12 @@
+SUMMARY = "The low-level, core functionality of boto 3."
+HOMEPAGE = "https://github.com/boto/botocore"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2ee41112a44fe7014dce33e26468ba93"
+
+SRC_URI = "git://github.com/boto/botocore.git;protocol=https"
+SRCREV = "8c7123bd4683049dcac62bf3e11662e6a72c5eec"
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+RDEPENDS_${PN} += "python3-jmespath python3-dateutil python3-logging"

--- a/recipes-devtools/python/python3-s3transfer_0.3.6.bb
+++ b/recipes-devtools/python/python3-s3transfer_0.3.6.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Amazon S3 Transfer Manager for Python"
+HOMEPAGE = "https://github.com/boto/s3transfer"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b1e01b26bacfc2232046c90a330332b3"
+
+SRC_URI = "git://github.com/boto/s3transfer.git;protocol=https"
+SRCREV = "fb386e433c11c961b1cab3178c31fd1b33056931"
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+RDEPENDS_${PN} += "python3-botocore \
+                   python3-asyncio \
+                   python3-urllib3 \
+                   python3-multiprocessing"

--- a/recipes-support/awscli/awscli_1.19.36.bb
+++ b/recipes-support/awscli/awscli_1.19.36.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Universal Command Line Interface for Amazon Web Services"
+HOMEPAGE = "https://github.com/aws/aws-cli"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=7970352423db76abb33cbe303884afbf"
+
+SRC_URI = "git://github.com/aws/aws-cli.git;protocol=https"
+SRCREV = "079f03758d0db7f430cc5f9787e5982a0586375a"
+S = "${WORKDIR}/git"
+
+inherit setuptools3
+
+RDEPENDS_${PN} += "python3-botocore \
+                   python3-docutils \
+                   python3-s3transfer \
+                   python3-pyyaml \
+                   python3-colorama \
+                   python3-distro \
+                   python3-unixadmin \
+                   python3-ruamel-yaml \
+                   python3-prompt-toolkit \
+                   python3-sqlite3 \
+                   python3-misc \
+                   python3-rsa"


### PR DESCRIPTION
This adds a recipes for awscli and its dependencies. It's sometimes useful to have aws on a custom linux distro for development and debugging purposes. The first patch in the series makes the layer depend on meta-python.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
