### PR TITLE
fix python3-jmespath recipe to properly build ver. 0.10.0 on branch gatesgarth

### DIFF
--- a/recipes-support/python3-jmespath/python3-jmespath_0.10.0.bb
+++ b/recipes-support/python3-jmespath/python3-jmespath_0.10.0.bb
@@ -2,11 +2,11 @@ SUMMARY = "JMESPath"
 DESCRIPTION = ""
 HOMEPAGE = ""
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=2683790f5fabb41a3f75b70558799eb4"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2683790f5fabb41a3f75b70558799eb4"
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/jmespath/jmespath.py.git;tag=v1.0.2"
+SRC_URI = "git://github.com/jmespath/jmespath.py.git;tag=0.10.0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
 - SRC_URI modified to point to tag 0.10.0
 - LIC_FILES_CHKSUM modified to fetch file LICENSE.txt (file LICENSE doesn't
   exist)

*Issue #, if available:* No issue available

*Description of changes:* On branch gatesgarth, recipe `python3-jmespath` doesn't build because the recipe points to a non-existent tag (see variable `SRC_URI`). Additionally, no 'LICENSE' file exists in the `jmespath` repository, leading to an error when trying to build the package; so, I also updated the name of the LICENSE file (see variable `LIC_FILES_CHKSUM`)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
