### PR TITLE
awscli: add groff as a runtime dependency

### DIFF
--- a/recipes-support/awscli/awscli_1.19.36.bb
+++ b/recipes-support/awscli/awscli_1.19.36.bb
@@ -20,4 +20,5 @@ RDEPENDS_${PN} += "python3-botocore \
                    python3-prompt-toolkit \
                    python3-sqlite3 \
                    python3-misc \
-                   python3-rsa"
+                   python3-rsa \
+                   groff"


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:* 
awscli depends on groff to format the help text. As this is a runtime dependency it doesn't cause a build failure but does result in a error when using the the utility.*

*Local Test:*
Appended awscli to my image install. Booted the image, confirmed `groff` was installed by running `groff --version`, then I ran `aws help` without an error and confirmed the help text was formatted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
