### PR TITLE
chore(release): create Greengrass 2.1/2.2/2.3 recipes

### DIFF
--- a/recipes-iot/aws-iot-greengrass/README.md
+++ b/recipes-iot/aws-iot-greengrass/README.md
@@ -6,6 +6,12 @@ See the AWS IoT Greengrass V1 section if you still require V1.
 
 ## AWS IoT Greengrass V2
 
+These images are provided for AWS IoT Greengrass V2:
+* `greengrass-bin`: This installs Greengrass v2 without a configuration file. This can be used if you plan to add logic to configure Greengrass when the device runs for the first time
+* `greengrass-bin-demo`: This installs Greengrass v2 and configures it to run using the provided certificates and configs. Use this if you want the image to be specific to a device, or to get started quickly.
+
+If you want to use a version of greengrass that is not the latest, you can provide `PREFERRED_VERSION_greengrass-bin` and `PREFERRED_VERSION_greengrass-bin-demo` (if used) to use latest.
+
 ### Add systemd
 
 Greengrass v2 runs more elegantly using systemd.  Add this to your

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.1.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.1.0.bb
@@ -1,0 +1,46 @@
+SUMMARY     = "AWS IoT Greengrass Nucleus - Binary Distribution - demo mode"
+DESCRIPTION = ""
+LICENSE     = "Apache-2"
+
+S                          = "${WORKDIR}"
+GG_BASENAME                = "greengrass/v2"
+GG_ROOT                    = "${D}/${GG_BASENAME}"
+LIC_FILES_CHKSUM           = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+SRC_URI                    = "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-nucleus/main/LICENSE;name=license; \
+                              file://greengrassv2-init.yaml \
+                              file://demo.pkey.pem          \
+                              file://demo.cert.pem          \
+                              file://demo.root.pem          \
+                              "
+SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
+SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
+
+RDEPENDS_${PN} += "greengrass-bin"
+
+do_configure[noexec] = "1"
+do_compile[noexec]   = "1"
+
+do_install() {
+    install -d ${GG_ROOT}/auth
+    install -d ${GG_ROOT}/config
+    install -m 0440 ${WORKDIR}/demo.pkey.pem ${GG_ROOT}/auth
+    install -m 0440 ${WORKDIR}/demo.cert.pem ${GG_ROOT}/auth
+    install -m 0440 ${WORKDIR}/demo.root.pem ${GG_ROOT}/auth
+
+    install -m 0640 ${WORKDIR}/greengrassv2-init.yaml ${GG_ROOT}/config/config.yaml
+
+    sed -i -e "s,##private_key##,/${GG_BASENAME}/auth/demo.pkey.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##certificate_path##,/${GG_BASENAME}/auth/demo.cert.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##root_ca##,/${GG_BASENAME}/auth/demo.root.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##thing_name##,${GGV2_THING_NAME},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##aws_region##,${GGV2_REGION},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##role_alias##,${GGV2_TES_RALIAS},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##posixUser##,ggc_user:ggc_group,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##iot_cred_endpoint##,${GGV2_CRED_EP},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##iot_data_endpoint##,${GGV2_DATA_EP},g" ${GG_ROOT}/config/config.yaml
+}
+
+FILES = ""
+FILES_${PN} = "/${GG_BASENAME}"
+
+INSANE_SKIP_${PN} += "already-stripped ldflags file-rdeps"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.2.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.2.0.bb
@@ -1,0 +1,46 @@
+SUMMARY     = "AWS IoT Greengrass Nucleus - Binary Distribution - demo mode"
+DESCRIPTION = ""
+LICENSE     = "Apache-2"
+
+S                          = "${WORKDIR}"
+GG_BASENAME                = "greengrass/v2"
+GG_ROOT                    = "${D}/${GG_BASENAME}"
+LIC_FILES_CHKSUM           = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+SRC_URI                    = "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-nucleus/main/LICENSE;name=license; \
+                              file://greengrassv2-init.yaml \
+                              file://demo.pkey.pem          \
+                              file://demo.cert.pem          \
+                              file://demo.root.pem          \
+                              "
+SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
+SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
+
+RDEPENDS_${PN} += "greengrass-bin"
+
+do_configure[noexec] = "1"
+do_compile[noexec]   = "1"
+
+do_install() {
+    install -d ${GG_ROOT}/auth
+    install -d ${GG_ROOT}/config
+    install -m 0440 ${WORKDIR}/demo.pkey.pem ${GG_ROOT}/auth
+    install -m 0440 ${WORKDIR}/demo.cert.pem ${GG_ROOT}/auth
+    install -m 0440 ${WORKDIR}/demo.root.pem ${GG_ROOT}/auth
+
+    install -m 0640 ${WORKDIR}/greengrassv2-init.yaml ${GG_ROOT}/config/config.yaml
+
+    sed -i -e "s,##private_key##,/${GG_BASENAME}/auth/demo.pkey.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##certificate_path##,/${GG_BASENAME}/auth/demo.cert.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##root_ca##,/${GG_BASENAME}/auth/demo.root.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##thing_name##,${GGV2_THING_NAME},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##aws_region##,${GGV2_REGION},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##role_alias##,${GGV2_TES_RALIAS},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##posixUser##,ggc_user:ggc_group,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##iot_cred_endpoint##,${GGV2_CRED_EP},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##iot_data_endpoint##,${GGV2_DATA_EP},g" ${GG_ROOT}/config/config.yaml
+}
+
+FILES = ""
+FILES_${PN} = "/${GG_BASENAME}"
+
+INSANE_SKIP_${PN} += "already-stripped ldflags file-rdeps"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.3.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin-demo_2.3.0.bb
@@ -1,0 +1,46 @@
+SUMMARY     = "AWS IoT Greengrass Nucleus - Binary Distribution - demo mode"
+DESCRIPTION = ""
+LICENSE     = "Apache-2"
+
+S                          = "${WORKDIR}"
+GG_BASENAME                = "greengrass/v2"
+GG_ROOT                    = "${D}/${GG_BASENAME}"
+LIC_FILES_CHKSUM           = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+SRC_URI                    = "https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-nucleus/main/LICENSE;name=license; \
+                              file://greengrassv2-init.yaml \
+                              file://demo.pkey.pem          \
+                              file://demo.cert.pem          \
+                              file://demo.root.pem          \
+                              "
+SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
+SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
+
+RDEPENDS_${PN} += "greengrass-bin"
+
+do_configure[noexec] = "1"
+do_compile[noexec]   = "1"
+
+do_install() {
+    install -d ${GG_ROOT}/auth
+    install -d ${GG_ROOT}/config
+    install -m 0440 ${WORKDIR}/demo.pkey.pem ${GG_ROOT}/auth
+    install -m 0440 ${WORKDIR}/demo.cert.pem ${GG_ROOT}/auth
+    install -m 0440 ${WORKDIR}/demo.root.pem ${GG_ROOT}/auth
+
+    install -m 0640 ${WORKDIR}/greengrassv2-init.yaml ${GG_ROOT}/config/config.yaml
+
+    sed -i -e "s,##private_key##,/${GG_BASENAME}/auth/demo.pkey.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##certificate_path##,/${GG_BASENAME}/auth/demo.cert.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##root_ca##,/${GG_BASENAME}/auth/demo.root.pem,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##thing_name##,${GGV2_THING_NAME},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##aws_region##,${GGV2_REGION},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##role_alias##,${GGV2_TES_RALIAS},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##posixUser##,ggc_user:ggc_group,g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##iot_cred_endpoint##,${GGV2_CRED_EP},g" ${GG_ROOT}/config/config.yaml
+    sed -i -e "s,##iot_data_endpoint##,${GGV2_DATA_EP},g" ${GG_ROOT}/config/config.yaml
+}
+
+FILES = ""
+FILES_${PN} = "/${GG_BASENAME}"
+
+INSANE_SKIP_${PN} += "already-stripped ldflags file-rdeps"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.0.3.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.0.3.bb
@@ -17,7 +17,7 @@ SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5
 
 GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
 RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
-RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers"
+RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers sudo"
 
 do_configure[noexec] = "1"
 do_compile[noexec]   = "1"

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.1.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.1.0.bb
@@ -6,12 +6,12 @@ S                          = "${WORKDIR}"
 GG_BASENAME                = "greengrass/v2"
 GG_ROOT                    = "${D}/${GG_BASENAME}"
 LIC_FILES_CHKSUM           = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
-SRC_URI                    = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-2.2.0.zip;name=payload; \
+SRC_URI                    = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-2.1.0.zip;name=payload; \
                               https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-nucleus/main/LICENSE;name=license; \
                               file://greengrassv2-init.yaml \
                               "
-SRC_URI[payload.md5sum]    = "51d11a951a86d4f5aed36d178b16e894"
-SRC_URI[payload.sha256sum] = "740b632750928b969c02ff4f28fd8ce6298be8fadbd854f211d713a80129c7cd"
+SRC_URI[payload.md5sum]    = "b2452d2ef6d7dec1706244d5766c6821"
+SRC_URI[payload.sha256sum] = "aef0d0d6e2f1f37dd5de106f980d02ef041fdae2cc89f7d478cf7f17e64bb830"
 SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.2.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.2.0.bb
@@ -1,0 +1,74 @@
+SUMMARY     = "AWS IoT Greengrass Nucleus - Binary Distribution"
+DESCRIPTION = ""
+LICENSE     = "Apache-2"
+
+S                          = "${WORKDIR}"
+GG_BASENAME                = "greengrass/v2"
+GG_ROOT                    = "${D}/${GG_BASENAME}"
+LIC_FILES_CHKSUM           = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+SRC_URI                    = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-2.2.0.zip;name=payload; \
+                              https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-nucleus/main/LICENSE;name=license; \
+                              file://greengrassv2-init.yaml \
+                              "
+SRC_URI[payload.md5sum]    = "51d11a951a86d4f5aed36d178b16e894"
+SRC_URI[payload.sha256sum] = "740b632750928b969c02ff4f28fd8ce6298be8fadbd854f211d713a80129c7cd"
+SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
+SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
+
+GG_USESYSTEMD = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'yes', 'no', d)}"
+RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'ntp-systemd', '', d)}"
+RDEPENDS_${PN} += "corretto-11-bin ca-certificates python3 python3-json python3-numbers"
+
+do_configure[noexec] = "1"
+do_compile[noexec]   = "1"
+
+do_install() {
+    install -d ${GG_ROOT}/config
+    install -d ${GG_ROOT}/alts
+    install -d ${GG_ROOT}/alts/init
+    install -d ${GG_ROOT}/alts/init/distro
+    install -d ${GG_ROOT}/alts/init/distro/bin
+    install -d ${GG_ROOT}/alts/init/distro/conf
+    install -d ${GG_ROOT}/alts/init/distro/lib
+    
+    install -m 0440 ${WORKDIR}/LICENSE                         ${GG_ROOT}
+    install -m 0640 ${WORKDIR}/greengrassv2-init.yaml          ${GG_ROOT}/config/config.yaml
+    install -m 0640 ${WORKDIR}/bin/greengrass.service.template ${GG_ROOT}/alts/init/distro/bin/greengrass.service.template
+    install -m 0640 ${WORKDIR}/bin/loader                      ${GG_ROOT}/alts/init/distro/bin/loader
+    install -m 0640 ${WORKDIR}/conf/recipe.yaml                ${GG_ROOT}/alts/init/distro/conf/recipe.yaml
+    install -m 0740 ${WORKDIR}/lib/Greengrass.jar              ${GG_ROOT}/alts/init/distro/lib/Greengrass.jar
+
+    cd ${GG_ROOT}/alts
+    ln -s -r /${GG_ROOT}/alts/init current
+    
+    # Install systemd service file
+    install -d ${D}${systemd_unitdir}/system/
+    install -m 0644 ${WORKDIR}/bin/greengrass.service.template ${D}${systemd_unitdir}/system/greengrass.service
+    sed -i -e "s,REPLACE_WITH_GG_LOADER_FILE,/${GG_BASENAME}/alts/current/distro/bin/loader,g" ${D}${systemd_unitdir}/system/greengrass.service
+    sed -i -e "s,REPLACE_WITH_GG_LOADER_PID_FILE,/var/run/greengrass.pid,g" ${D}${systemd_unitdir}/system/greengrass.service
+}
+
+FILES_${PN} = "/${GG_BASENAME} \
+               ${sysconfdir} \
+               ${systemd_unitdir}"
+
+CONFFILES_${PN} += "/${GG_BASENAME}/config/config.yaml.clean"
+
+inherit systemd
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE_${PN} = "greengrass.service"
+
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM_${PN} = "-r ggc_group"
+USERADD_PARAM_${PN} = "-r -M -N -g ggc_group -s /bin/false ggc_user"
+
+#
+# Disable failing QA checks:
+#
+#   Binary was already stripped
+#   No GNU_HASH in the elf binary
+#
+INSANE_SKIP_${PN} += "already-stripped ldflags file-rdeps"
+

--- a/recipes-iot/aws-iot-greengrass/greengrass-bin_2.3.0.bb
+++ b/recipes-iot/aws-iot-greengrass/greengrass-bin_2.3.0.bb
@@ -6,12 +6,12 @@ S                          = "${WORKDIR}"
 GG_BASENAME                = "greengrass/v2"
 GG_ROOT                    = "${D}/${GG_BASENAME}"
 LIC_FILES_CHKSUM           = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
-SRC_URI                    = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-2.2.0.zip;name=payload; \
+SRC_URI                    = "https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-2.3.0.zip;name=payload; \
                               https://raw.githubusercontent.com/aws-greengrass/aws-greengrass-nucleus/main/LICENSE;name=license; \
                               file://greengrassv2-init.yaml \
                               "
-SRC_URI[payload.md5sum]    = "51d11a951a86d4f5aed36d178b16e894"
-SRC_URI[payload.sha256sum] = "740b632750928b969c02ff4f28fd8ce6298be8fadbd854f211d713a80129c7cd"
+SRC_URI[payload.md5sum]    = "7e1beacf403f3a64be4c364d07b3ba20"
+SRC_URI[payload.sha256sum] = "923a6099d633113871cce12122a5b420c6e2d58b27bc30c60badac1f084993b4"
 SRC_URI[license.md5sum]    = "34400b68072d710fecd0a2940a0d1658"
 SRC_URI[license.sha256sum] = "09e8a9bcec8067104652c168685ab0931e7868f9c8284b66f5ae6edae5f1130b"
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* 
* Adds the images for greengrass 2.1.0, 2.2.0 and 2.3.0 which were released in 2021.
* Adds sudo dependency to greengrass-bin, as it is used by AWS IoT Greengrass v2 to run components with the specified username, and also required by IoT Device Tester to qualify a Greengrass device.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
