### PR TITLE
fix armv7 download for dunfell branch

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.9.12.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-11-bin_11.0.9.12.1.bb
@@ -8,7 +8,7 @@ BASE_aarch64    = "amazon-corretto-${PV}-linux-aarch64"
 SRC_URI_aarch64 = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-aarch64.tar.gz;name=aarch64"
 
 BASE_arm        = "amazon-corretto-${PV}-linux-armv7"
-SRC_URI_arm     = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-.tar.gz;name=arm"
+SRC_URI_arm     = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-armv7.tar.gz;name=arm"
 
 BASE_x86-64     = "amazon-corretto-${PV}-linux-x64"
 SRC_URI_x86-64  = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"


### PR DESCRIPTION
*Issue #, if available:* -

*Description of changes:*
I checked out the current dunfell branch and noticed it does not build greengrass v2 bin for ARM because corretto fetch sources task is failing. Cherry picked the missing commit from meta-aws master.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
