### PR TITLE
recipes-sdk: do not overwrite/clear PACKAGES variable

### DIFF
--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.4.9.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.4.9.bb
@@ -33,6 +33,5 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.4.5.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.4.5.bb
@@ -30,7 +30,6 @@ EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-common/aws-c-common_0.4.67.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.4.67.bb
@@ -21,6 +21,5 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.2.10.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.2.10.bb
@@ -32,7 +32,6 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.6.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.6.bb
@@ -34,7 +34,6 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-http/aws-c-http_0.5.9.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.5.9.bb
@@ -37,7 +37,6 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-io/aws-c-io_0.8.3.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.8.3.bb
@@ -32,7 +32,6 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.0.2.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.0.2.bb
@@ -27,7 +27,6 @@ EXTRA_OECMAKE += "-DCMAKE_PREFIX_PATH=$D/usr"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.5.5.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.5.5.bb
@@ -33,7 +33,6 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.1.4.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.1.4.bb
@@ -33,6 +33,5 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
+++ b/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
@@ -34,7 +34,6 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.11.8.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.11.8.bb
@@ -45,7 +45,6 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2.inc
@@ -30,6 +30,5 @@ FILES_${PN} += "${libdir}/libIotJobs-cpp.so"
 FILES_${PN} += "${libdir}/libIotShadow-cpp.so"
 FILES_${PN} += "${libdir}/libs2n.so"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.5.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.5.bb
@@ -43,6 +43,5 @@ FILES_${PN} += "${libdir}/libIotSecureTunneling-cpp.so"
 FILES_${PN} += "${libdir}/libs2n.so"
 FILES_${PN}-dev += "${includedir}/aws/iotidentity/IotIdentityClient.h"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-iot-greengrass-sdk/aws-greengrass-core-sdk-c_git.bb
+++ b/recipes-sdk/aws-iot-greengrass-sdk/aws-greengrass-core-sdk-c_git.bb
@@ -20,7 +20,5 @@ do_install_append() {
 FILES_${PN} += "${libdir}/libaws-greengrass-core-sdk-c.so"
 FILES_${PN} += "${includedir}/greengrasssdk.h"
 
-PACKAGES = "${PN}"
-
 # just ignore produced debug files by cmake build system
 INSANE_SKIP_${PN} += "installed-vs-shipped"

--- a/recipes-sdk/s2n/s2n_0.10.26.bb
+++ b/recipes-sdk/s2n/s2n_0.10.26.bb
@@ -26,6 +26,5 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
-PACKAGES = "${PN}"
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Clearing PACKAGES variable to only contain ${PN} is very bad and it's not clear
what the purpose is. It doesn't cause much trouble during the regular build for
the target, as do_populate_sysroot() is able to collect required artifacts. But
since there are no ${PN}-dev, ${PN}-dbg and ${PN}-staticdev packages produced,
it renders an SDK with AWS IoT components completely useless, especially since
majority of them only produce .a libraries.

This change removes overwriting/clearing of the PACKAGES variable to use the
default value. If it was done as a workaround for some other issue, a better
solution should be found and not this "sledgehammer approach".

Signed-off-by: Denys Dmytriyenko <denis@denix.org>
