### PR TITLE
build dependencies fixed - change commit hash to point to fix

### DIFF
--- a/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
+++ b/recipes-iot/aws-iot-securetunneling-localproxy/aws-iot-securetunneling-localproxy_git.bb
@@ -1,0 +1,34 @@
+# -*- mode: Conf; -*-
+SUMMARY = "AWS Iot Secure Tunneling local proxy reference C++ implementation"
+DESCRIPTION = "When devices are deployed behind restricted firewalls at remote sites, you need a way to gain access to those device for troubleshooting, configuration updates, and other operational tasks. Secure tunneling helps customers establish bidirectional communication to remote devices over a secure connection that is managed by AWS IoT. Secure tunneling does not require updates to your existing inbound firewall rule, so you can keep the same security level provided by firewall rules at a remote site. "
+HOMEPAGE = "https://docs.aws.amazon.com/iot/latest/developerguide/secure-tunneling.html"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+DEPENDS += "boost catch2 openssl protobuf protobuf-native zlib"
+
+PV = "1.0+git${SRCPV}"
+SRC_URI = "git://git@github.com/aws-samples/aws-iot-securetunneling-localproxy.git;protocol=ssh"
+SRCREV = "b5bc3d3e250089ace65b55adf1835eab19642e45"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+do_configure:prepend() {
+    sed -i "s/Protobuf_LITE_STATIC_LIBRARY/Protobuf_LITE_LIBRARY/g" ${S}/CMakeLists.txt
+    sed -i "s/string.*Protobuf_LITE_LIBRARY.*/#&/g" ${S}/CMakeLists.txt
+    sed -i "s/set_property.*PROTOBUF_USE_STATIC_LIBS.*/#&/g" ${S}/CMakeLists.txt
+}
+
+do_install () {
+  install -d ${D}${bindir}
+  install -m 0755 ${B}/bin/localproxy ${D}${bindir}/localproxy
+  install -m 0755 ${B}/bin/localproxytest ${D}${bindir}/localproxytest
+}
+
+PACKAGES =+ "${PN}-tests"
+FILES:${PN} = "${bindir}/localproxy"
+FILES:${PN}-tests = "${bindir}/localproxytest"
+RDEPENDS:${PN}-tests += "${PN}"


### PR DESCRIPTION
*Issue #, if available:*

Fixes #140 

*Description of changes:*

Change commit hash to https://github.com/aws-samples/aws-iot-securetunneling-localproxy/commit/b5bc3d3e250089ace65b55adf1835eab19642e45 which makes modification to boost dependency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
