### PR TITLE
[dunfell] recipes-sdk: enable packaging of unversioned .so into ${PN}

### DIFF
--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2.inc
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2.inc
@@ -29,6 +29,7 @@ FILES_${PN} += "${libdir}/libIotIdentity-cpp.so"
 FILES_${PN} += "${libdir}/libIotJobs-cpp.so"
 FILES_${PN} += "${libdir}/libIotShadow-cpp.so"
 FILES_${PN} += "${libdir}/libs2n.so"
+FILES_SOLIBSDEV = ""
 
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.5.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.5.bb
@@ -42,6 +42,7 @@ FILES_${PN} += "${libdir}/libIotDeviceDefender-cpp.so"
 FILES_${PN} += "${libdir}/libIotSecureTunneling-cpp.so"
 FILES_${PN} += "${libdir}/libs2n.so"
 FILES_${PN}-dev += "${includedir}/aws/iotidentity/IotIdentityClient.h"
+FILES_SOLIBSDEV = ""
 
 INSANE_SKIP_${PN} += "installed-vs-shipped"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-iot-greengrass-sdk/aws-greengrass-core-sdk-c_git.bb
+++ b/recipes-sdk/aws-iot-greengrass-sdk/aws-greengrass-core-sdk-c_git.bb
@@ -19,6 +19,7 @@ do_install_append() {
 }
 FILES_${PN} += "${libdir}/libaws-greengrass-core-sdk-c.so"
 FILES_${PN} += "${includedir}/greengrasssdk.h"
+FILES_SOLIBSDEV = ""
 
 # just ignore produced debug files by cmake build system
 INSANE_SKIP_${PN} += "installed-vs-shipped"


### PR DESCRIPTION
According to Debian policy, shared libraries should be versioned and named
as libNAME.so.X.Y.Z, while unversioned libNAME.so being a symlink to the
actual lib and only needed at build time, not at runtime. Hence OE normally
packages .so into ${PN}-dev and not into main ${PN}.

Allow packaging unversioned .so libraries into the main ${PN} package by
resetting FILES_SOLIBSDEV, that would otherwise let ${PN}-dev grab them and
cause this error:

QA Issue: -dev package aws-iot-device-sdk-cpp-v2-dev contains non-symlink .so '/usr/lib/libDiscovery-cpp.so'

Signed-off-by: Denys Dmytriyenko <denis@denix.org>
