### PR TITLE
Remove extra layers from checklayer conf

### DIFF
--- a/qa/checklayer/conf/bblayers.conf
+++ b/qa/checklayer/conf/bblayers.conf
@@ -8,8 +8,4 @@ BBFILES ?= ""
 BBLAYERS ?= " \
   DIST/poky/meta \
   DIST/poky/meta-poky \
-  DIST/meta-openembedded/meta-oe \
-  DIST/meta-openembedded/meta-python \
-  DIST/meta-openembedded/meta-networking \
-  DIST/meta-openembedded/meta-filesystems \
   "


### PR DESCRIPTION
The extra layers cause an error when running checklayer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
