### PR TITLE
incorrect package split for '0unstable' links to denote unstable ABI …

### DIFF
--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
@@ -31,10 +31,10 @@ EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
 OECMAKE_BUILDPATH += "${WORKDIR}/build"
 
-FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
-FILES:${PN}-dev = "${includedir}/aws/iotdevice/* \
-                   ${libdir}/lib${PN}.so \
+FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.0unstable"
+FILES:${PN}-dev = "${includedir}/aws/iotdevice/* \
+                   ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-iot/* \
                    ${libdir}/aws-c-iot/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
@@ -35,10 +35,10 @@ OECMAKE_BUILDPATH += "${WORKDIR}/build"
 OECMAKE_SOURCEPATH += "${S}"
 
 
-FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
-FILES:${PN}-dev = "${includedir}/aws/s3/* \
-                   ${libdir}/lib${PN}.so \
+FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.0unstable"
+FILES:${PN}-dev = "${includedir}/aws/s3/* \
+                   ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-s3/* \
                    ${libdir}/aws-c-s3/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.14.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.14.1.bb
@@ -32,7 +32,8 @@ EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON"
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 EXTRA_OECMAKE += "-DCMAKE_INSTALL_PREFIX=$D/usr"
 
-FILES:${PN}     = "${libdir}/*.so"
+FILES:${PN}     = "${libdir}/*.so \
+                   ${libdir}/lib${PN}.so.0unstable"
 FILES:${PN}-dev = "${includedir}/aws/* \
                    ${libdir}/GreengrassIpc-cpp/* \
                    ${libdir}/IotDeviceDefender-cpp/* \
@@ -44,8 +45,7 @@ FILES:${PN}-dev = "${includedir}/aws/* \
                    ${libdir}/IotSecureTunneling-cpp/* \
                    ${libdir}/EventstreamRpc-cpp/* \
                    ${libdir}/IotJobs-cpp/* \
-                   ${libdir}/lib${PN}.so \
-                   ${libdir}/lib${PN}.so.0unstable"
+                   ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-iot-device-sdk-cpp-v2/* \
                    ${libdir}/.debug/lib*"
 

--- a/recipes-sdk/aws-lc/aws-lc_0.0.1.bb
+++ b/recipes-sdk/aws-lc/aws-lc_0.0.1.bb
@@ -33,9 +33,7 @@ OECMAKE_SOURCEPATH += "${S}"
 FILES:${PN}     = "${libdir}/aws-lc/lib/libssl.so \
                    ${libdir}/aws-lc/lib/libcrypto.so \
                    ${libdir}/aws-lc/lib/libdecrepit.so"
-FILES:${PN}-dev = "${libdir}/aws-lc/include/openssl/* \
-                   ${libdir}/lib${PN}.so \
-                   ${libdir}/lib${PN}.so.0unstable"
+FILES:${PN}-dev = "${libdir}/aws-lc/include/openssl/*"
 FILES:${PN}-dbg = "/usr/src/debug/aws-lc/* \
                    ${libdir}/aws-lc/lib/ssl/* \
                    ${libdir}/aws-lc/lib/AWSLC/* \


### PR DESCRIPTION
…- see respective CMakefile files

*Issue #, if available:*

N/A

*Description of changes:*

Not shipping symlink in correct package split

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
