### PR TITLE
move cmake files from -dbg to -dev, fixes #179

### DIFF
--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.6.1.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.6.1.bb
@@ -40,7 +40,6 @@ FILES:${PN}-dev = "${includedir}/aws/auth/* \
                    ${libdir}/aws-c-auth/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-auth/* \
-                   ${libdir}/aws-c-auth/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.5.11.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.5.11.bb
@@ -19,7 +19,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix
 S = "${WORKDIR}/git"
 
 DEPENDS = "openssl s2n aws-c-common"
-RDEPENDS_${PN} = "s2n aws-c-common"
+RDEPENDS:${PN} = "s2n aws-c-common"
 
 CFLAGS:append = " -Wl,-Bsymbolic"
 OECMAKE_SOURCEPATH = "${S}/aws-c-cal"
@@ -32,10 +32,9 @@ EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/cal/* \
-                   ${libdir}/cmake/* \
+                   ${libdir}/aws-c-cal/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-cal/* \
-                   ${libdir}/aws-c-cal/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-common/aws-c-common_0.6.8.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.6.8.bb
@@ -29,9 +29,9 @@ FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
 FILES:${PN}-dev = "${includedir}/aws/common/* \
                    ${includedir}/aws/testing/* \
                    ${libdir}/cmake/* \
+                   ${libdir}/aws-c-common/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-common/* \
-                   ${libdir}/aws-c-common/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.2.14.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.2.14.bb
@@ -35,9 +35,9 @@ OECMAKE_SOURCEPATH += "${S}"
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/compression/* \
+                   ${libdir}/aws-c-compression/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-compression/* \
-                   ${libdir}/aws-c-compression/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_
 S = "${WORKDIR}/git"
 
 DEPENDS = "openssl s2n aws-c-common aws-checksums aws-c-io"
-RDEPENDS_${PN} = "s2n aws-c-common aws-checksums aws-c-io"
+RDEPENDS:${PN} = "s2n aws-c-common aws-checksums aws-c-io"
 
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-event-stream"
@@ -37,9 +37,9 @@ OECMAKE_SOURCEPATH += "${S}"
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/event-stream/* \
+                   ${libdir}/aws-c-event-stream/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-event-stream/* \
-                   ${libdir}/aws-c-event-stream/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-http/aws-c-http_0.6.5.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.6.5.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_
 S = "${WORKDIR}/git"
 
 DEPENDS = "openssl s2n aws-c-common aws-c-cal aws-c-io aws-c-compression"
-RDEPENDS_${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression"
+RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression"
 
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-http"
@@ -38,9 +38,9 @@ OECMAKE_SOURCEPATH += "${S}"
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/http/* \
+                   ${libdir}/aws-c-http/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-http/* \
-                   ${libdir}/aws-c-http/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-io/aws-c-io_0.10.7.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.10.7.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_
 S = "${WORKDIR}/git"
 
 DEPENDS = "openssl s2n aws-c-common aws-c-cal"
-RDEPENDS_${PN} = "s2n aws-c-common aws-c-cal"
+RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal"
 
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-c-io"
@@ -36,9 +36,9 @@ OECMAKE_SOURCEPATH += "${S}"
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/io/* \
                    ${includedir}/aws/testing/* \
+                   ${libdir}/aws-c-io/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-io/* \
-                   ${libdir}/aws-c-io/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix
 S = "${WORKDIR}/git"
 
 DEPENDS = "aws-crt-cpp"
-RDEPENDS_${PN} = "aws-crt-cpp"
+RDEPENDS:${PN} = "aws-crt-cpp"
 
 OECMAKE_SOURCEPATH = "${S}/aws-c-iot"
 CFLAGS:append = " -Wl,-Bsymbolic"
@@ -34,9 +34,9 @@ OECMAKE_BUILDPATH += "${WORKDIR}/build"
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.0unstable"
 FILES:${PN}-dev = "${includedir}/aws/iotdevice/* \
+                   ${libdir}/aws-c-iot/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-iot/* \
-                   ${libdir}/aws-c-iot/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_
 S = "${WORKDIR}/git"
 
 DEPENDS = "openssl s2n aws-c-common aws-c-cal aws-c-io aws-c-compression aws-c-http"
-RDEPENDS_${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression aws-c-http"
+RDEPENDS:${PN} = "s2n aws-c-common aws-c-cal aws-c-io aws-c-compression aws-c-http"
 
 OECMAKE_SOURCEPATH = "${S}/aws-c-mqtt"
 CFLAGS:append = " -Wl,-Bsymbolic"
@@ -36,9 +36,9 @@ OECMAKE_SOURCEPATH += "${S}"
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/mqtt/* \
+                   ${libdir}/aws-c-mqtt/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-mqtt/* \
-                   ${libdir}/aws-c-mqtt/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 INSANE_SKIP:${PN} += "installed-vs-shipped"

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
@@ -21,7 +21,7 @@ SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_
 S= "${WORKDIR}/git"
 
 DEPENDS = "openssl aws-c-auth aws-c-http"
-RDEPENDS_${PN} = "aws-c-auth aws-c-http"
+RDEPENDS:${PN} = "aws-c-auth aws-c-http"
 
 CFLAGS:append = " -Wl,-Bsymbolic"
 
@@ -38,9 +38,9 @@ OECMAKE_SOURCEPATH += "${S}"
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0 \
                    ${libdir}/lib${PN}.so.0unstable"
 FILES:${PN}-dev = "${includedir}/aws/s3/* \
+                   ${libdir}/aws-c-s3/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-c-s3/* \
-                   ${libdir}/aws-c-s3/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
+++ b/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
@@ -22,7 +22,7 @@ SRCREV_checksums = "99bb0ad4b89d335d638536694352c45e0d2188f5"
 S = "${WORKDIR}/git"
 
 DEPENDS = "openssl s2n aws-c-common"
-RDEPENDS_${PN} = "s2n aws-c-common"
+RDEPENDS:${PN} = "s2n aws-c-common"
 
 AWS_C_INSTALL = "$D/usr"
 OECMAKE_SOURCEPATH = "${S}/aws-checksums"
@@ -39,9 +39,9 @@ OECMAKE_SOURCEPATH += "${S}"
 
 FILES:${PN}     = "${libdir}/lib${PN}.so.1.0.0"
 FILES:${PN}-dev = "${includedir}/aws/checksums/* \
+                   ${libdir}/aws-checksums/* \
                    ${libdir}/lib${PN}.so"
 FILES:${PN}-dbg = "/usr/src/debug/aws-checksums/* \
-                   ${libdir}/aws-checksums/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.15.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.15.0.bb
@@ -48,9 +48,9 @@ OECMAKE_SOURCEPATH += "${S}/aws-crt-cpp"
 
 FILES:${PN} += "${libdir}/libaws-crt-cpp.so"
 FILES:${PN}-dev = "${includedir}/aws/crt/* \
+                   ${libdir}/aws-crt-cpp/* \
                    ${includedir}/aws/iot/*"
 FILES:${PN}-dbg = "/usr/src/debug/aws-crt-cpp/* \
-                   ${libdir}/aws-crt-cpp/* \
                    ${libdir}/.debug/lib${PN}.so.1.0.0"
 
 # Notify that libraries are not versioned

--- a/recipes-sdk/aws-lc/aws-lc_0.0.1.bb
+++ b/recipes-sdk/aws-lc/aws-lc_0.0.1.bb
@@ -33,11 +33,11 @@ OECMAKE_SOURCEPATH += "${S}"
 FILES:${PN}     = "${libdir}/aws-lc/lib/libssl.so \
                    ${libdir}/aws-lc/lib/libcrypto.so \
                    ${libdir}/aws-lc/lib/libdecrepit.so"
-FILES:${PN}-dev = "${libdir}/aws-lc/include/openssl/*"
-FILES:${PN}-dbg = "/usr/src/debug/aws-lc/* \
+FILES:${PN}-dev = "${libdir}/aws-lc/include/openssl/* \
                    ${libdir}/aws-lc/lib/ssl/* \
                    ${libdir}/aws-lc/lib/AWSLC/* \
                    ${libdir}/aws-lc/lib/crypto/*"
+FILES:${PN}-dbg = "/usr/src/debug/aws-lc/*"
 
 BBCLASSEXTEND = "native nativesdk"
 

--- a/recipes-sdk/s2n/s2n_1.0.13.bb
+++ b/recipes-sdk/s2n/s2n_1.0.13.bb
@@ -36,9 +36,9 @@ FILES:${PN} += "${libdir}/libs2n.so"
 
 
 FILES:${PN}     = "${libdir}/libs2n.so"
-FILES:${PN}-dev = "${includedir}/s2n.h"
+FILES:${PN}-dev = "${includedir}/s2n.h \
+                   ${libdir}/s2n/*"
 FILES:${PN}-dbg = "/usr/src/debug/s2n/* \
-                   ${libdir}/s2n/* \
                    ${libdir}/.debug/libs2n.so"
 
 # Notify that libraries are not versioned


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

change cmake file package split target from -dbg to -dev

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
