### PR TITLE
aws-cli: fix dependencies and bump version

### DIFF
--- a/recipes-support/awscli/awscli_1.19.36.bb
+++ b/recipes-support/awscli/awscli_1.19.36.bb
@@ -9,16 +9,18 @@ S = "${WORKDIR}/git"
 
 inherit setuptools3
 
-RDEPENDS:${PN} += "python3-botocore \
-                   python3-docutils \
-                   python3-s3transfer \
-                   python3-pyyaml \
-                   python3-colorama \
-                   python3-distro \
-                   python3-unixadmin \
-                   python3-ruamel-yaml \
-                   python3-prompt-toolkit \
-                   python3-sqlite3 \
-                   python3-misc \
-                   python3-rsa \
-                   groff"
+RDEPENDS:${PN} += " \
+    python3-botocore \
+    python3-docutils \
+    python3-s3transfer \
+    python3-pyyaml \
+    python3-colorama \
+    python3-distro \
+    python3-unixadmin \
+    python3-ruamel-yaml \
+    python3-prompt-toolkit \
+    python3-sqlite3 \
+    python3-misc \
+    python3-rsa \
+    groff \
+"

--- a/recipes-support/awscli/awscli_1.19.36.bb
+++ b/recipes-support/awscli/awscli_1.19.36.bb
@@ -22,5 +22,8 @@ RDEPENDS:${PN} += " \
     python3-sqlite3 \
     python3-misc \
     python3-rsa \
+    python3-dateutil \
+    python3-urllib3 \
+    python3-jmespath \
     groff \
 "

--- a/recipes-support/awscli/awscli_1.20.54.bb
+++ b/recipes-support/awscli/awscli_1.20.54.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=7970352423db76abb33cbe303884afbf"
 
 SRC_URI = "git://github.com/aws/aws-cli.git;protocol=https"
-SRCREV = "079f03758d0db7f430cc5f9787e5982a0586375a"
+SRCREV = "bf9bb5b60cd24b97d642646c7f7d6c17e320c576"
 S = "${WORKDIR}/git"
 
 inherit setuptools3


### PR DESCRIPTION
The following PR contains some coding style changes in the awscli recipe, adds missing runtime dependencies and bumps the version of the awscli to the most recent 1.x.y release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
