### PR TITLE
corretto-17-bin: add corretto 17 bin library

### DIFF
--- a/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.0.35.1.bb
+++ b/recipes-devtools/amazon-corretto/corretto-17-bin_17.0.0.35.1.bb
@@ -1,0 +1,74 @@
+# -*- mode: Conf; -*-
+SUMMARY     = "Amazon Corretto 17"
+DESCRIPTION = ""
+LICENSE = "GPL-2"
+
+LIC_FILES_CHKSUM = "file://../${BASE}/LICENSE;md5=3e0b59f8fac05c3c03d4a26bbda13f8f"
+SHR             = "amazon-corretto-${PV}"
+BASE:aarch64    = "amazon-corretto-${PV}-linux-aarch64"
+SRC_URI:aarch64 = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-aarch64.tar.gz;name=aarch64"
+
+BASE:x86-64     = "amazon-corretto-${PV}-linux-x64"
+SRC_URI:x86-64  = "https://corretto.aws/downloads/resources/${PV}/amazon-corretto-${PV}-linux-x64.tar.gz;name=x86-64"
+
+SRC_URI[aarch64.md5sum]    = "7a5bbd3a5be41d86a20b38806f74b343"
+SRC_URI[aarch64.sha256sum] = "54e006a27909655bb77e201bc018148377e4f2dca892cd5838984f7f22a05700"
+
+SRC_URI[x86-64.md5sum]     = "e658fcede95579a2ffb1fa429c56d69c"
+SRC_URI[x86-64.sha256sum]  = "4005f04eaeb0be6460f5f5b13904f8a2619540aa2ce7632fd86fa302bcae6077"
+
+FILES = ""
+FILES:${PN} = "/usr/lib/${SHR} /usr/bin"
+
+do_install() {
+    install -d ${D}/usr/bin
+    install -d ${D}/usr/lib/${SHR}
+    cp -r ${WORKDIR}/${BASE}/* ${D}/usr/lib/${SHR}/
+    cd ${D}/usr/bin
+    ln -s ../lib/${SHR}/bin/jaotc
+    ln -s ../lib/${SHR}/bin/jarsigner
+    ln -s ../lib/${SHR}/bin/javac
+    ln -s ../lib/${SHR}/bin/javap
+    ln -s ../lib/${SHR}/bin/jconsole
+    ln -s ../lib/${SHR}/bin/jdeprscan
+    ln -s ../lib/${SHR}/bin/jfr
+    ln -s ../lib/${SHR}/bin/jimage
+    ln -s ../lib/${SHR}/bin/jjs
+    ln -s ../lib/${SHR}/bin/jmap
+    ln -s ../lib/${SHR}/bin/jps
+    ln -s ../lib/${SHR}/bin/jshell
+    ln -s ../lib/${SHR}/bin/jstat
+    ln -s ../lib/${SHR}/bin/keytool
+    ln -s ../lib/${SHR}/bin/rmic
+    ln -s ../lib/${SHR}/bin/rmiregistry
+    ln -s ../lib/${SHR}/bin/unpack200
+    ln -s ../lib/${SHR}/bin/jar
+    ln -s ../lib/${SHR}/bin/java
+    ln -s ../lib/${SHR}/bin/javadoc
+    ln -s ../lib/${SHR}/bin/jcmd
+    ln -s ../lib/${SHR}/bin/jdb
+    ln -s ../lib/${SHR}/bin/jdeps
+    ln -s ../lib/${SHR}/bin/jhsdb
+    ln -s ../lib/${SHR}/bin/jinfo
+    ln -s ../lib/${SHR}/bin/jlink
+    ln -s ../lib/${SHR}/bin/jmod
+    ln -s ../lib/${SHR}/bin/jrunscript
+    ln -s ../lib/${SHR}/bin/jstack
+    ln -s ../lib/${SHR}/bin/jstatd
+    ln -s ../lib/${SHR}/bin/pack200
+    ln -s ../lib/${SHR}/bin/rmid
+    ln -s ../lib/${SHR}/bin/serialver
+}
+
+do_install:append:x86-64() {
+    # create symbolic link /lib64/ld-linux-x86-64.so.2 to enable
+    # loading the binary When maintainers build binaries on ubuntu,
+    # this is the library they are linking to, and if we don't set it
+    # up this way on the device, the program will not run.
+    install -d ${D}/lib64
+    cd ${D}/lib64
+    ln -s ../lib/ld-linux-x86-64.so.2 ld-linux-x86-64.so.2
+}
+
+FILES:${PN} += " /lib64"
+INSANE_SKIP:${PN} += " libdir"


### PR DESCRIPTION
Tested with `java -version` and using javac/java on a small hello world
application on qemux86-64 and qemuarm64.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
