### PR TITLE
git: update protocol for github recipes

### DIFF
--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.0.1.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.0.1.bb
@@ -6,7 +6,7 @@ PROVIDES += "aws/aws-iot-device-client"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3eb31626add6ada64ff9ac772bd3c653"
 
 BRANCH ?= "main"
-SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;branch=${BRANCH};bareclone=0"
+SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;protocol=https;branch=${BRANCH};bareclone=0"
 SRCREV = "16b73b81da29149581a433cf7b6e69fcdd11176a"
 
 S= "${WORKDIR}/git"

--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.1.0.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.1.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3eb31626add6ada64ff9ac772bd3c653"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;branch=${BRANCH};tag=v1.1"
+SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;protocol=https;branch=${BRANCH};tag=v1.1"
 
 S= "${WORKDIR}/git"
 PACKAGES = "${PN}"

--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.2.0.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.2.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3eb31626add6ada64ff9ac772bd3c653"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;branch=${BRANCH};tag=v1.2 \
+SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;protocol=https;branch=${BRANCH};tag=v1.2 \
 "
 
 S= "${WORKDIR}/git"

--- a/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.4.0.bb
+++ b/recipes-iot/aws-iot-device-client/aws-iot-device-client_1.4.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3eb31626add6ada64ff9ac772bd3c653"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;branch=${BRANCH};tag=v1.4 \
+SRC_URI = "git://github.com/awslabs/aws-iot-device-client.git;protocol=https;branch=${BRANCH};tag=v1.4 \
            file://01-missing-thread-includes.patch \
            file://02-missing-thread-includes.patch \
 "

--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.4.9.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.4.9.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-auth/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-auth.git;branch=${BRANCH};destsuffix=${S}/aws-c-auth;name=auth \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-auth.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-auth;name=auth \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-auth/aws-c-auth_0.6.1.bb
+++ b/recipes-sdk/aws-c-auth/aws-c-auth_0.6.1.bb
@@ -13,8 +13,8 @@ LIC_FILES_CHKSUM = "file://aws-c-auth/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd
 BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-auth.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-auth;name=auth \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-auth.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-auth;name=auth \
 "
 
 S= "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.4.5.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.4.5.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-cal/LICENSE;md5=34400b68072d710fecd0a2940a0d165
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-cal.git;branch=${BRANCH};destsuffix=${S}/aws-c-cal;name=cal \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-cal.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-cal;name=cal \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-cal/aws-c-cal_0.5.11.bb
+++ b/recipes-sdk/aws-c-cal/aws-c-cal_0.5.11.bb
@@ -12,8 +12,8 @@ LIC_FILES_CHKSUM = "file://aws-c-cal/LICENSE;md5=34400b68072d710fecd0a2940a0d165
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;tag=v0.6.8 \
-           git://github.com/awslabs/aws-c-cal.git;branch=${BRANCH};destsuffix=${S}/aws-c-cal;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;tag=v0.6.8 \
+           git://github.com/awslabs/aws-c-cal.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-cal;tag=v${PV} \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-common/aws-c-common_0.4.67.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.4.67.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH}"
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH}"
 SRCREV = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"
 
 S= "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-common/aws-c-common_0.6.8.bb
+++ b/recipes-sdk/aws-c-common/aws-c-common_0.6.8.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH ?= "main"
 TAG ?= "v${PV}"
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG};"
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG};"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.2.10.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.2.10.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-compression/LICENSE;md5=3b83ef96387f14655fc854d
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-compression.git;branch=${BRANCH};destsuffix=${S}/aws-c-compression;name=compression \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-compression.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-compression;name=compression \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-compression/aws-c-compression_0.2.14.bb
+++ b/recipes-sdk/aws-c-compression/aws-c-compression_0.2.14.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-compression.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-compression;name=compression \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-compression.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-compression;name=compression \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.6.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.6.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-event-stream/LICENSE;md5=3b83ef96387f14655fc854
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-event-stream.git;branch=${BRANCH};destsuffix=${S}/aws-c-event-stream;name=es \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-event-stream.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-event-stream;name=es \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
+++ b/recipes-sdk/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-event-stream.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-event-stream;name=es \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-event-stream.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-event-stream;name=es \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-http/aws-c-http_0.5.9.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.5.9.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-http/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-http.git;branch=${BRANCH};destsuffix=${S}/aws-c-http;name=http \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-http.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-http;name=http \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-http/aws-c-http_0.6.5.bb
+++ b/recipes-sdk/aws-c-http/aws-c-http_0.6.5.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-http.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-http;name=http \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-http.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-http;name=http \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-io/aws-c-io_0.10.7.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.10.7.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-io.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-io;name=io \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-io.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-io;name=io \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-io/aws-c-io_0.8.3.bb
+++ b/recipes-sdk/aws-c-io/aws-c-io_0.8.3.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-io/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-io.git;branch=${BRANCH};destsuffix=${S}/aws-c-io;name=io \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-io.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-io;name=io \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.0.2.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.0.2.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-iot/LICENSE;md5=2ee41112a44fe7014dce33e26468ba9
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common;tag=v0.4.67 \
-           git://github.com/awslabs/aws-c-iot.git;branch=${BRANCH};destsuffix=${S}/aws-c-iot;name=iot;tag=v0.0.2 \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common;tag=v0.4.67 \
+           git://github.com/awslabs/aws-c-iot.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-iot;name=iot;tag=v0.0.2 \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
+++ b/recipes-sdk/aws-c-iot/aws-c-iot_0.0.7.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common;tag=${TAG_COMMON} \
-           git://github.com/awslabs/aws-c-iot.git;branch=${BRANCH};destsuffix=${S}/aws-c-iot;name=iot;tag=${TAG} \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common;tag=${TAG_COMMON} \
+           git://github.com/awslabs/aws-c-iot.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-iot;name=iot;tag=${TAG} \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.5.5.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.5.5.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-mqtt/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-mqtt.git;branch=${BRANCH};destsuffix=${S}/aws-c-mqtt;name=mqtt \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-mqtt.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-mqtt;name=mqtt \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-mqtt.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-mqtt;name=mqtt \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-mqtt.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-mqtt;name=mqtt \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.1.23.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-s3.git;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-s3;name=s3 \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-s3;name=s3 \
 "
 
 S= "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-s3/aws-c-s3_0.1.4.bb
+++ b/recipes-sdk/aws-c-s3/aws-c-s3_0.1.4.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-c-s3/LICENSE;md5=34400b68072d710fecd0a2940a0d1658
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-c-s3.git;branch=${BRANCH};destsuffix=${S}/aws-c-s3;name=s3 \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-c-s3.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-s3;name=s3 \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
+++ b/recipes-sdk/aws-checksums/aws-checksums_0.1.11.bb
@@ -12,8 +12,8 @@ LIC_FILES_CHKSUM = "file://aws-checksums/LICENSE;md5=e3fc50a88d0a364313df4b21ef2
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-checksums.git;branch=${BRANCH};destsuffix=${S}/aws-checksums;name=checksums \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-checksums.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-checksums;name=checksums \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.11.8.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.11.8.bb
@@ -11,8 +11,8 @@ LIC_FILES_CHKSUM = "file://aws-crt-cpp/LICENSE;md5=3b83ef96387f14655fc854ddc3c6b
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-crt-cpp.git;branch=${BRANCH};destsuffix=${S}/aws-crt-cpp;name=crtcpp \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-crt-cpp.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-crt-cpp;name=crtcpp \
 "
 
 SRCREV_common = "00c91eeb186970d50690ebbdceefdeae5c31fb4c"

--- a/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.15.0.bb
+++ b/recipes-sdk/aws-crt-cpp/aws-crt-cpp_0.15.0.bb
@@ -14,8 +14,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
-           git://github.com/awslabs/aws-crt-cpp.git;branch=${BRANCH};destsuffix=${S}/aws-crt-cpp;name=crtcpp \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
+           git://github.com/awslabs/aws-crt-cpp.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-crt-cpp;name=crtcpp \
 "
 
 # For this module, the tag doesn't work and the commit hash for the

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.10.3.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.10.3.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH ?= "main"
-SRC_URI = "git://github.com/awslabs/aws-crt-python.git;branch=${BRANCH}"
+SRC_URI = "git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH}"
 SRCREV = "d020399725065de2999c6743063d7fabf5e0dd9a"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.12.1.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.12.1.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH ?= "main"
-SRC_URI = "git://github.com/awslabs/aws-crt-python.git;branch=${BRANCH};tag=v0.12.1 \
+SRC_URI = "git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH};tag=v0.12.1 \
            file://fix-library-suffix.patch \
 "
 

--- a/recipes-sdk/aws-crt-python/aws-crt-python_0.5.11.bb
+++ b/recipes-sdk/aws-crt-python/aws-crt-python_0.5.11.bb
@@ -18,5 +18,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-crt-python.git;branch=${BRANCH};name=aws-crt-python"
+SRC_URI = "git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=${BRANCH};name=aws-crt-python"
 SRCREV = "2d19abb7fc360416202f9c590971c91c84dc2c72"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.0.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "d42acb94fe105b1b1c00ed97d2e9dc434153edf6"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.4.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.4.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "24c73fac2ed1e13c931d3b825523862161efedd0"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.5.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.10.5.bb
@@ -10,8 +10,8 @@ LIC_FILES_CHKSUM = "file://aws-iot-device-sdk-cpp-v2/LICENSE;md5=f91e61641e7a968
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;tag=v0.5.3 \
-           git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};destsuffix=${S}/aws-iot-device-sdk-cpp-v2;tag=v1.10.5 \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;tag=v0.5.3 \
+           git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-iot-device-sdk-cpp-v2;tag=v1.10.5 \
            file://001-move-c-iot-include.patch \
 "
 

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.14.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.14.1.bb
@@ -13,8 +13,8 @@ BRANCH ?= "main"
 TAG ?= "v${PV}"
 TAG_COMMON ?= "v0.6.8"
 
-SRC_URI = "git://github.com/awslabs/aws-c-common.git;branch=${BRANCH};destsuffix=${S}/aws-c-common;tag=${TAG_COMMON} \
-           git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};destsuffix=${S}/aws-iot-device-sdk-cpp-v2;tag=${TAG} \
+SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-c-common;tag=${TAG_COMMON} \
+           git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};destsuffix=${S}/aws-iot-device-sdk-cpp-v2;tag=${TAG} \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.0.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "65b8344ddb6173d312dff4e759a0dfbc05a97e4c"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.1.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "efd6f1b340a7f56f7558a0490a6c78fa2dd253ba"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.2.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.6.2.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "536b66e6c52686eebdca377b6d1fc48aa64976e3"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.0.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "7fa9d625bb033dc91a7ec308b805bdae540273cd"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.1.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "4deb855bea43e32e976abf562a468fdaf0af7945"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.2.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.2.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "38f166a5baa2f50b4d55e274778a3b2a4c1dd082"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.3.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.3.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "8daf749ca958aa9c69a821f821adea8abc7f53fe"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.4.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.4.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "e147bd2d44e7ab7121ffeecabf9d408ba1e4fc19"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.5.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.7.5.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "6bd68f8264da777b84ff43e0ca32025389ac5848"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.0.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "4fc97e24f19956f7f35de714e6b4e13078d193e7"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.1.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.1.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "db18431f948522b73dae57d3f45be93c411d154e"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.2.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.2.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "b7a5dd3eb7d89d799c5928d9c041696a7850a3a9"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.3.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.3.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "a39d21970b2fabb442e6c19a18e05ee0e1c3b7ea"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.4.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.8.4.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "f34823176ea3077d8436476318d78347caaca902"

--- a/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.9.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.9.0.bb
@@ -5,5 +5,5 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-cpp-v2"
 SRCREV = "0978d93ce82c06a3871383fed69f3810e71b20fb"

--- a/recipes-sdk/aws-iot-device-sdk-python-v1/aws-iot-device-sdk-python-v1.inc
+++ b/recipes-sdk/aws-iot-device-sdk-python-v1/aws-iot-device-sdk-python-v1.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9ac49901b833e769c7d6f21e8dbd7b30"
 
 BRANCH ?= "master"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v1"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-python-v1"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.5.4.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.5.4.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 inherit setuptools3
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-python-v2"
 SRCREV = "a7739a6f980292ae146e064b18f3f2723019261e"
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.7.0.bb
+++ b/recipes-sdk/aws-iot-device-sdk-python-v2/aws-iot-device-sdk-python-v2_1.7.0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f91e61641e7a96835dea6926a65f4702"
 inherit setuptools3
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;branch=${BRANCH};name=aws-iot-device-sdk-python-v2;tag=v1.7.0"
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-python-v2.git;protocol=https;branch=${BRANCH};name=aws-iot-device-sdk-python-v2;tag=v1.7.0"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-sdk/aws-lc/aws-lc_0.0.2.bb
+++ b/recipes-sdk/aws-lc/aws-lc_0.0.2.bb
@@ -13,7 +13,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c1afc79d796415ed8191ba3258b73e3a"
 BRANCH ?= "main"
 TAG ?= "v${PV}"
 
-SRC_URI = "git://github.com/awslabs/aws-lc.git;branch=${BRANCH};tag=${TAG}"
+SRC_URI = "git://github.com/awslabs/aws-lc.git;protocol=https;branch=${BRANCH};tag=${TAG}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-sdk/s2n/s2n_0.10.26.bb
+++ b/recipes-sdk/s2n/s2n_0.10.26.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=26d85861cd0c0d05ab56ebff38882975"
 
 BRANCH ?= "main"
 
-SRC_URI = "git://github.com/awslabs/s2n.git;branch=${BRANCH}"
+SRC_URI = "git://github.com/awslabs/s2n.git;protocol=https;branch=${BRANCH}"
 SRCREV = "49c46200d6a6b5aee76c5f9adb86c329a737a6ca"
 
 S= "${WORKDIR}/git"

--- a/recipes-sdk/s2n/s2n_1.0.13.bb
+++ b/recipes-sdk/s2n/s2n_1.0.13.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=26d85861cd0c0d05ab56ebff38882975"
 
 BRANCH ?= "main"
 TAG ?= "v${PV}"
-SRC_URI = "git://github.com/aws/s2n-tls.git;branch=${BRANCH};tag=${TAG} \
+SRC_URI = "git://github.com/aws/s2n-tls.git;protocol=https;branch=${BRANCH};tag=${TAG} \
            file://0002-cmakelists-remove-warn.patch \
 "
 


### PR DESCRIPTION
GitHub is deprecating `git://` protocol. To accomodate this, bitbake
allows setting `;protocol=https` to the fetched URL.

The following command was used:

`grep "git://github.com" . | grep -v "protocol=https" | cut -f 1 -d ':' | uniq | xargs sed -i -E -e "s|(git://github.com/[^;]+)|\1;protocol=https|"`

Then the neo-ai recipe was reset because it's slightly more complicated.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
