### PR TITLE
Patch: Fix missing macro

### DIFF
--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -16,6 +16,7 @@ TAG_COMMON ?= "v0.6.8"
 
 SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
            git://github.com/awslabs/aws-c-mqtt.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-mqtt;name=mqtt \
+           file://fix-missing-macro.patch
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -16,7 +16,7 @@ TAG_COMMON ?= "v0.6.8"
 
 SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
            git://github.com/awslabs/aws-c-mqtt.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-mqtt;name=mqtt \
-           file://fix-missing-macro.patch
+           file://fix-missing-macro.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-sdk/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -16,7 +16,7 @@ TAG_COMMON ?= "v0.6.8"
 
 SRC_URI = "git://github.com/awslabs/aws-c-common.git;protocol=https;branch=${BRANCH};tag=${TAG_COMMON};destsuffix=${S}/aws-c-common;name=common \
            git://github.com/awslabs/aws-c-mqtt.git;protocol=https;branch=${BRANCH};tag=${TAG};destsuffix=${S}/aws-c-mqtt;name=mqtt \
-           file://fix-missing-macro.patch \
+           file://fix-missing-macro.patch;patchdir=${S}/aws-c-mqtt/ \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-sdk/aws-c-mqtt/files/fix-missing-macro.patch
+++ b/recipes-sdk/aws-c-mqtt/files/fix-missing-macro.patch
@@ -1,0 +1,24 @@
+From 4f85a8719ce9a21140c1fd89e6cf959747bc6d67 Mon Sep 17 00:00:00 2001
+From: Rephael Congmon <rephcongmon@gmail.com>
+Date: Fri, 5 Nov 2021 10:31:19 -0700
+Subject: [PATCH] Added missing macro
+
+---
+ include/aws/mqtt/client.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/aws/mqtt/client.h b/include/aws/mqtt/client.h
+index 06c8636..9263f26 100644
+--- a/include/aws/mqtt/client.h
++++ b/include/aws/mqtt/client.h
+@@ -418,6 +418,7 @@ int aws_mqtt_client_connection_connect(
+  * \returns AWS_OP_SUCCESS if the connection has been successfully initiated,
+  *              otherwise AWS_OP_ERR and aws_last_error() will be set.
+  */
++AWS_MQTT_API
+ int aws_mqtt_client_connection_reconnect(
+     struct aws_mqtt_client_connection *connection,
+     aws_mqtt_client_on_connection_complete_fn *on_connection_complete,
+-- 
+2.33.0
+


### PR DESCRIPTION
*Description of changes:*
Added missing AWS_MQTT_API macro in patch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
